### PR TITLE
Add speed control and movement command

### DIFF
--- a/lib/buffer/buffer.h
+++ b/lib/buffer/buffer.h
@@ -51,11 +51,9 @@
 #define DRIVER_ADDRESS 0b00 // TMC Driver address according to MS1 and MS2
 #define R_SENSE 0.11f // Match to your driver
 
-inline constexpr double SPEED_MM_S = 30.0;
+inline constexpr double SPEED_MM_S_DEFAULT = 30.0;
 inline constexpr double SPEED_MULTIPLIER = 9.1463414634;
-inline constexpr double SPEED_RPM = SPEED_MM_S * SPEED_MULTIPLIER; // speed in r/min
 inline constexpr int32_t MOVE_DIVIDE_NUM = 16;
-inline constexpr uint32_t VACTUAL_VALUE = static_cast<uint32_t>(SPEED_RPM * MOVE_DIVIDE_NUM * 200.0f / 60.0f / 0.715f);
 
 #define STOP 0 // stop
 #define I_CURRENT (600) // motor current


### PR DESCRIPTION
## Summary
- allow configuring movement speed via `set_speed` command
- report speed during startup and via `q`
- add `move` command for single movement in mm
- stop continuous mode when filament runs out

## Testing
- `clang-format -i lib/buffer/*.cpp lib/buffer/*.h src/*.cpp`
- `pio run -e fly_buffer_f072c8`
- `pio check`


------
https://chatgpt.com/codex/tasks/task_e_68715a1658108320916946d91b57471d